### PR TITLE
1047. Remove All Adjacent Duplicates In String

### DIFF
--- a/rust/src/solution/mod.rs
+++ b/rust/src/solution/mod.rs
@@ -2,3 +2,4 @@ mod min_cost_climbing_stairs;
 mod minimum_number_of_refueling_stops;
 mod matchsticks_to_square;
 mod pascals_triangle;
+mod remove_all_adjacent_duplicates_in_string;

--- a/rust/src/solution/remove_all_adjacent_duplicates_In_string.rs
+++ b/rust/src/solution/remove_all_adjacent_duplicates_In_string.rs
@@ -1,0 +1,27 @@
+pub struct Solution {}
+
+impl Solution {
+    pub fn remove_duplicates(s: String) -> String {
+        let mut stack: Vec<char> = vec![];
+        for c in s.chars() {
+            if let Some(last_char) = stack.last() {
+                if *last_char == c {
+                    stack.remove(stack.len() - 1);
+                    continue;
+                }
+            }
+            stack.push(c);
+        }
+        stack.iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        assert_eq!("ca".to_string(), Solution::remove_duplicates("abbaca".to_string()));
+    }
+}


### PR DESCRIPTION
## やったこと

1. stackにcharをつむ
2. 積むときにすでに積んであったら最後のものと比較し、一致していればstackから消す
3. 最後にstackを結合したものが答え

## 問題のURL

https://leetcode.com/problems/remove-all-adjacent-duplicates-in-string/

## その他(感想など)

最近、難しい問題ばかりでなかなかPR出せずにすみません。。。。
rust脳になりきれてない＋問題が難しく実装がすんなりできないで、
何かと詰まって解決できていませんでした、、、、w